### PR TITLE
Refactor validators/encoders to be classes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
     "prefer-arrow-callback": ["error", { "allowNamedFunctions": true }],
     "prefer-template": ["error"],
     "quote-props": ["error", "consistent-as-needed"],
-    "quotes": ["error", "single"]
+    "quotes": ["error", "single"],
+    "semi": ["error"]
   }
 }

--- a/src/encoder/base62.ts
+++ b/src/encoder/base62.ts
@@ -1,6 +1,0 @@
-import base from 'base-x';
-
-// base62 alphabet as noted: https://en.wikipedia.org/wiki/Base62
-const { encode, decode } = base('0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz');
-
-export { encode, decode };

--- a/src/encoder/basex.ts
+++ b/src/encoder/basex.ts
@@ -1,0 +1,21 @@
+import base, { BaseConverter } from 'base-x';
+import { Encoder } from './encoder';
+
+export interface BaseXEncoderOpts {
+    alphabet: string;
+}
+
+export class BaseXEncoder implements Encoder {
+    private readonly encoder: BaseConverter;
+    constructor(opts: BaseXEncoderOpts) {
+        this.encoder = base(opts.alphabet);
+    }
+
+    encode(data: Uint8Array): string {
+        return this.encoder.encode(data);
+    }
+
+    decode(data: string): Uint8Array {
+        return this.encoder.decode(data);
+    }
+}

--- a/src/encoder/encoder.ts
+++ b/src/encoder/encoder.ts
@@ -1,0 +1,4 @@
+export interface Encoder {
+    encode(data: Uint8Array): string;
+    decode(data: string): Uint8Array;
+}

--- a/src/encoder/index.ts
+++ b/src/encoder/index.ts
@@ -1,1 +1,2 @@
-export * as Base62Encoder from './base62'
+export * from './basex';
+export * from './encoder';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,17 @@
 import { Crc32Validator } from './validator';
-import { Base62Encoder } from './encoder';
+import { BaseXEncoder } from './encoder';
 import * as Token from './token';
 
+const base62Encoder = new BaseXEncoder({
+    // base62 alphabet by default noted: https://en.wikipedia.org/wiki/Base62
+    alphabet: '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
+});
+
+const crc32Validator = new Crc32Validator();
+
 const Crc32Token = Token.ReadableTokenGenerator({
-    integrity: Crc32Validator,
-    encoder: Base62Encoder,
+    integrity: crc32Validator,
+    encoder: base62Encoder,
 });
 
 const ReadableToken = Token.ReadableTokenGenerator({
@@ -12,15 +19,15 @@ const ReadableToken = Token.ReadableTokenGenerator({
         check: (data: Uint8Array) => data,
         generate: (data: Uint8Array) => data,
     },
-    encoder: Base62Encoder,
+    encoder: base62Encoder,
 });
 
 export {
-    Crc32Validator,
-    Base62Encoder,
-    ReadableToken,
     Crc32Token,
+    ReadableToken,
 };
 
+export * from './validator';
+export * from './encoder';
 export * from './token';
 export * from './error';

--- a/src/token.ts
+++ b/src/token.ts
@@ -1,6 +1,8 @@
 import { rng } from './util/rng';
 import { parse as parseUuid, stringify as formatUuid } from 'uuid';
 import { InvalidTokenError } from './error';
+import { Encoder } from './encoder';
+import { Validator } from './validator';
 
 export interface Token {
     prefix: string;
@@ -59,19 +61,9 @@ export interface TokenGenerator {
     validate(token: string, prefix?: string): Token;
 }
 
-export interface Encoder {
-    encode(data: Uint8Array): string;
-    decode(data: string): Uint8Array;
-}
-
-export interface Integrity {
-    check(data: Uint8Array): Uint8Array;
-    generate(data: Uint8Array): Uint8Array;
-}
-
 export interface TokenOpts {
     encoder: Encoder;
-    integrity: Integrity;
+    integrity: Validator;
 }
 
 function generate(prefix: string, byteLength: number): Promise<string>;
@@ -129,5 +121,5 @@ export function ReadableTokenGenerator({ encoder, integrity }: TokenOpts): Token
             });
             return t;
         },
-    }
+    };
 }

--- a/src/validator/crc32.ts
+++ b/src/validator/crc32.ts
@@ -1,6 +1,7 @@
 import { buf } from 'crc-32';
 import { timingSafeEqual } from 'crypto';
 import { InvalidTokenError } from '../error';
+import { Validator } from './validator';
 
 function calculateCrc32(val: Uint8Array): Buffer {
     const crc32 = Buffer.allocUnsafe(4);
@@ -8,27 +9,29 @@ function calculateCrc32(val: Uint8Array): Buffer {
     return crc32;
 }
 
-/**
- * Validates the CRC32 check value for given input
- *
- * @param {Uint8Array} val The value to check
- * @returns Uint8Array
- */
-export function check(val: Uint8Array): Uint8Array {
-    const data = val.subarray(0, -4);
-    const crc32 = val.subarray(-4);
-    if (!timingSafeEqual(crc32, calculateCrc32(data))) {
-        throw new InvalidTokenError('Invalid CRC32 check value');
+export class Crc32Validator implements Validator {
+    /**
+     * Calculates the CRC32 check value for a given buffer
+     *
+     * @param {Buffer} val
+     * @returns {Buffer}
+     */
+    generate(val: Uint8Array): Uint8Array {
+        return Buffer.concat([val, calculateCrc32(val)]);
     }
-    return data;
-}
 
-/**
- * Calculates the CRC32 check value for a given buffer
- *
- * @param {Buffer} val
- * @returns {Buffer}
- */
-export function generate(val: Uint8Array): Buffer {
-    return Buffer.concat([val, calculateCrc32(val)]);
+    /**
+     * Validates the CRC32 check value for given input
+     *
+     * @param {Uint8Array} val The value to check
+     * @returns Uint8Array
+     */
+    check(val: Uint8Array): Uint8Array {
+        const data = val.subarray(0, -4);
+        const crc32 = val.subarray(-4);
+        if (!timingSafeEqual(crc32, calculateCrc32(data))) {
+            throw new InvalidTokenError('Invalid CRC32 check value');
+        }
+        return data;
+    }
 }

--- a/src/validator/index.ts
+++ b/src/validator/index.ts
@@ -1,1 +1,2 @@
-export * as Crc32Validator from './crc32';
+export * from './crc32';
+export * from './validator';

--- a/src/validator/validator.ts
+++ b/src/validator/validator.ts
@@ -1,0 +1,4 @@
+export interface Validator {
+    check(data: Uint8Array): Uint8Array;
+    generate(data: Uint8Array): Uint8Array;
+}

--- a/test/encoder.ts
+++ b/test/encoder.ts
@@ -1,9 +1,12 @@
 import { expect } from 'chai';
-import { Base62Encoder } from '../src';
+import { BaseXEncoder } from '../src';
 
 describe('Base62Encoder', () => {
     it('has methods', () => {
-        expect(Base62Encoder).to.have.property('encode');
-        expect(Base62Encoder).to.have.property('decode');
+        const inst = new BaseXEncoder({
+            alphabet: '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
+        });
+        expect(inst).to.have.property('encode');
+        expect(inst).to.have.property('decode');
     });
 });

--- a/test/validator.ts
+++ b/test/validator.ts
@@ -3,7 +3,8 @@ import { Crc32Validator } from '../src';
 
 describe('Crc32Validator', () => {
     it('has methods', () => {
-        expect(Crc32Validator).to.have.property('check');
-        expect(Crc32Validator).to.have.property('generate');
+        const inst = new Crc32Validator();
+        expect(inst).to.have.property('check');
+        expect(inst).to.have.property('generate');
     });
 });


### PR DESCRIPTION
This refactors the encoders/validators to be classes which are instantiated and used.

The Base62Encoder is replaced with a generic `BaseXEncoder` which allows consumers to provider their own alphabets, if needed.

This change means the exports of the library have changed and so this is a breaking change for those that relied on some of those exports.

To do:

- [ ] update docs