### PR TITLE
improve test coverage / behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,12 @@ const token = await Crc32Token.generate('prefix', '8ece30ba-b1fc-4944-8758-75b20
 NB: It's important to note that this library isn't hiding or making the UUID a secret, it's just a different format to
 represent the data that is encoded in a UUID.
 
-
 ## Token Types
 
 There are two types of tokens available in the library by default. A "plain" `ReadableToken`, which has no integrity
 checking, which means it is faster to generate, but at the trade-off that there is no ability to check the integrity of
-tokens without hitting a database or token store. This could be something worth thinking about when you're thinking of 
-trying to reject tokens [at the edge](https://en.wikipedia.org/wiki/Edge_computing), or when you want to be able to use
+tokens without hitting a database or token store. This could be something worth thinking about when you may want to 
+reject tokens [at the edge](https://en.wikipedia.org/wiki/Edge_computing), or when you want to be able to use
 efficient [secret scanning](https://docs.github.com/en/code-security/secret-scanning/about-secret-scanning).
 
 As inspired by GitHub tokens, and to provide a way to be able to do some quick offline validation of tokens, there is
@@ -91,6 +90,24 @@ const customTokenType = new ReadableTokenGenerator({
             }
             throw new Error('HMAC did not validate');
         },
+    },
+});
+```
+
+### Custom encoding aplphabets
+
+The library also exports a `BaseXEncoder` class which is instantiated with an `alphabet` prop. This allows for the use
+of a custom alphabet.
+
+```js
+const { BaseXEncoder, ReadableTokenGenerator } = require('readable-tokens');
+const encoder = new BaseXEncoder({ alphabet: 'abcdefghijklmnopqrstuvwxyz' });
+
+const customTokenType = new ReadableTokenGenerator({
+    // encode as base64 using native buffer support
+    encoder: {
+        encode: (val) => Buffer.from(val).toString('base64').replace(/=+$/, ''),
+        decode: (val) => Buffer.from(val, 'base64'),
     },
 });
 ```

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const customTokenType = new ReadableTokenGenerator({
 });
 ```
 
-### Custom encoding aplphabets
+### Custom encoding alphabets
 
 The library also exports a `BaseXEncoder` class which is instantiated with an `alphabet` prop. This allows for the use
 of a custom alphabet.
@@ -103,11 +103,7 @@ of a custom alphabet.
 const { BaseXEncoder, ReadableTokenGenerator } = require('readable-tokens');
 const encoder = new BaseXEncoder({ alphabet: 'abcdefghijklmnopqrstuvwxyz' });
 
-const customTokenType = new ReadableTokenGenerator({
-    // encode as base64 using native buffer support
-    encoder: {
-        encode: (val) => Buffer.from(val).toString('base64').replace(/=+$/, ''),
-        decode: (val) => Buffer.from(val, 'base64'),
-    },
+const customTokenType = ReadableTokenGenerator({
+    encoder,
 });
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,6 @@ const Crc32Token = Token.ReadableTokenGenerator({
 });
 
 const ReadableToken = Token.ReadableTokenGenerator({
-    integrity: {
-        check: (data: Uint8Array) => data,
-        generate: (data: Uint8Array) => data,
-    },
     encoder: base62Encoder,
 });
 

--- a/src/token.ts
+++ b/src/token.ts
@@ -63,7 +63,7 @@ export interface TokenGenerator {
 
 export interface TokenOpts {
     encoder: Encoder;
-    integrity: Validator;
+    integrity?: Validator;
     prng?: typeof rng;
 }
 
@@ -90,8 +90,12 @@ function generate(this: { prng: typeof rng, format: (prefix: string, val: Uint8A
 }
 
 export function ReadableTokenGenerator({ encoder, integrity, prng }: TokenOpts): TokenGenerator {
+    const validator: Validator = integrity ?? {
+        check: (data: Uint8Array) => data,
+        generate: (data: Uint8Array) => data,
+    };
     const formatToken = (prefix: string, data: Uint8Array) => {
-        return `${prefix}_${encoder.encode(integrity.generate(data))}`;
+        return `${prefix}_${encoder.encode(validator.generate(data))}`;
     };
     return {
         generate: generate.bind({ prng: prng ?? rng, format: formatToken }),
@@ -100,7 +104,7 @@ export function ReadableTokenGenerator({ encoder, integrity, prng }: TokenOpts):
             if (parts.length <= 1) {
                 throw new InvalidTokenError('Malformed token');
             }
-            const raw = integrity.check(encoder.decode(parts.pop() as string));
+            const raw = validator.check(encoder.decode(parts.pop() as string));
             const prefix = parts.join('_');
             if (expectedPrefix && expectedPrefix !== prefix) {
                 throw new InvalidTokenError('Prefix mismatch');

--- a/test/basex-token.ts
+++ b/test/basex-token.ts
@@ -1,0 +1,3 @@
+describe('base-x token', () => {
+    // test that default integrity is applied
+});

--- a/test/basex-token.ts
+++ b/test/basex-token.ts
@@ -1,3 +1,36 @@
-describe('base-x token', () => {
-    // test that default integrity is applied
+import { ReadableTokenGenerator, BaseXEncoder } from '../src';
+import { expect } from 'chai';
+
+const base62Encoder = new BaseXEncoder({
+    alphabet: '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
+});
+
+describe('ReadableTokenGenerator without integrity', () => {
+    const tokenType = ReadableTokenGenerator({
+        encoder: base62Encoder,
+    });
+
+    describe('generate()', () => {
+        it('generates a token', async () => {
+            const token = await tokenType.generate('test');
+            expect(token).to.match(/^test_[A-Za-z0-9]+$/);
+        });
+        it('generates a token from a uuid', () => {
+            const token = tokenType.generate('test', '00000000-0000-0000-0000-000000000000');
+            expect(token).to.equal('test_0000000000000000');
+        });
+    });
+
+    describe('validate()', () => {
+        it('validates a token without integrity checking', () => {
+            const token = tokenType.validate('test_7aVvodScBkSK7FhYEES7tf');
+            expect(token).to.have.property('prefix', 'test');
+            expect(token.toString()).to.equal('test_7aVvodScBkSK7FhYEES7tf');
+        });
+        it('round-trips a generated token', () => {
+            const generated = tokenType.generate('test', '8ece30ba-b1fc-4944-8758-75b20ebc1cc7');
+            const validated = tokenType.validate(generated);
+            expect(validated.toString('uuid')).to.equal('8ece30ba-b1fc-4944-8758-75b20ebc1cc7');
+        });
+    });
 });


### PR DESCRIPTION
Make the `integrity` option in `ReadableTokenGenerator` optional. When omitted, a no-op pass-through validator is used, simplifying the creation of tokens that do not need integrity checking.

## Changes

- Make `integrity` optional in `TokenOpts`, defaulting to a no-op validator
- Simplify `ReadableToken` in `index.ts` by dropping the inline no-op validator
- Add README section documenting custom encoding alphabets with `BaseXEncoder`
- Add tests for `ReadableTokenGenerator` without an integrity validator