### PR TITLE
ci: report code coverage summary using action summary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,20 +94,11 @@ jobs:
         run: npm clean-install
       - name: Test code
         run: npm run coverage -- --forbid-only
-      - name: Code Coverage Summary
-        uses: irongut/CodeCoverageSummary@v1.3.0
-        with:
-          filename: coverage/cobertura-coverage.xml
-          badge: true
-          format: markdown
-          output: both
-      - name: Add Coverage PR Comment
-        uses: marocchino/sticky-pull-request-comment@v2
-        if: github.event_name == 'pull_request'
-        continue-on-error: true
-        with:
-          recreate: true
-          path: code-coverage-results.md
+      - name: Code coverage summary
+        run: |
+          echo "# Code coverage" >> $GITHUB_STEP_SUMMARY
+          npx nyc report | sed --expression='1d;$d'  >> $GITHUB_STEP_SUMMARY
+        if: always()
   release:
     name: Release
     concurrency: release


### PR DESCRIPTION
Remove the PR comments for codecoverage and instead report them directy on the action.