### PR TITLE
feat: allow consumers to pass in a PRNG

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - codelint
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 20.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/test/custom.ts
+++ b/test/custom.ts
@@ -36,13 +36,14 @@ const customTokenType = ReadableTokenGenerator({
             throw new Error('HMAC did not validate');
         },
     },
+    prng: (length: number) => Promise.resolve(Buffer.from(new Array(length).fill(255))),
 });
 
 describe('custom token', () => {
     describe('generate()', () => {
-        it('generates a token', async () => {
+        it('generates a token using the supplied "prng"', async () => {
             const token = await customTokenType.generate('test');
-            expect(token).to.match(/^test_[A-Za-z0-9+/]{27}$/);
+            expect(token).to.equal('test_/////////////////////0J4sGg');
         });
         it('generates a token from a uuid', () => {
             const token = customTokenType.generate('test', '00000000-0000-0000-0000-000000000000');
@@ -50,7 +51,7 @@ describe('custom token', () => {
         });
         it('generates a token of arbitrary length', async () => {
             const token = await customTokenType.generate('test', 32);
-            expect(token).to.match(/^test_[A-Za-z0-9+/]+$/);
+            expect(token).to.equal('test_///////////////////////////////////////////x3Sgl');
         });
         it('generates a token from a buffer', () => {
             const token = customTokenType.generate('test', Buffer.from('GQI42CPM9GC'));


### PR DESCRIPTION
When constructing a TokenGenerator, a `prng` option can be provided to allow
overriding of the native (`crypto.randomBytes()`) call. This must be a function
that accepts a numeric argument (length of `Buffer` to return) and returns a `Promise`
that resolves to a `Buffer` with the requisite number of random bytes. This is primarily
useful for testing.