### PR TITLE
ci: pin changelog preset to v9 for writer compatibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,13 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+    ignore:
+      # The 10.x preset requires conventional-changelog-writer@9+, but
+      # @semantic-release/release-notes-generator still depends on ^8.0.0.
+      # Pairing them silently drops every commit from the release notes.
+      # Remove this once release-notes-generator ships a writer 9 dependency.
+      - dependency-name: "conventional-changelog-conventionalcommits"
+        update-types: ["version-update:semver-major"]
     groups:
       release-tools:
         patterns:

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@typescript-eslint/eslint-plugin": "^8.0.1",
         "@typescript-eslint/parser": "^8.0.1",
         "chai": "^4.3.7",
-        "conventional-changelog-conventionalcommits": "^10.2.0",
+        "conventional-changelog-conventionalcommits": "^9.3.1",
         "eslint": "^8.43.0",
         "mocha": "^11.0.1",
         "nyc": "^18.0.0",
@@ -543,19 +543,6 @@
         "node": ">=v18"
       }
     },
-    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
-      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "compare-func": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@commitlint/config-validator": {
       "version": "20.5.0",
       "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-20.5.0.tgz",
@@ -844,16 +831,6 @@
         "conventional-commits-parser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@conventional-changelog/template": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.3.0.tgz",
-      "integrity": "sha512-GsCw/qu92GI0EX6s7fxUi/SG1lmFjG9XZivxxEDZXqztuQKCn5o5wKdz4v005zci0Md7EZzgAwmQLoIEDZoaow==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -3085,16 +3062,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.3.0.tgz",
-      "integrity": "sha512-qag0zFD867Qq1DK0jAWicyWlEMS1FFC/BLVLISaoeI7Y6Em6aWchk7BCkhOTsecRpMsV6qX41XmlNnghiiTmSw==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.3.0"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@typescript-eslint/eslint-plugin": "^8.0.1",
     "@typescript-eslint/parser": "^8.0.1",
     "chai": "^4.3.7",
-    "conventional-changelog-conventionalcommits": "^10.2.0",
+    "conventional-changelog-conventionalcommits": "^9.3.1",
     "eslint": "^8.43.0",
     "mocha": "^11.0.1",
     "nyc": "^18.0.0",


### PR DESCRIPTION
## Problem

Release notes on `main` are silently rendering empty — just a version header, with every commit dropped.

`conventional-changelog-conventionalcommits@10.x` requires `conventional-changelog-writer@9` or newer. `@semantic-release/release-notes-generator@14.1.0` depends on `conventional-changelog-writer: ^8.0.0`, so the lockfile resolves writer **8.4.0**. A modern preset rendered through a legacy writer produces no sections at all, and does so without erroring.

This is already the state of `main` — it is not introduced by any pending Dependabot PR. The last few published releases (`v2.0.0`, `v1.3.0`) do have proper sections, so the breakage post-dates them and simply has not been exercised since.

## Evidence

Calling `generateNotes` from `@semantic-release/release-notes-generator` with two synthetic commits (one `feat:`, one `fix:`), against a clean checkout:

| preset | writer | output | sections |
|---|---|---|---|
| `^10.2.0` (`main` today, resolves 10.3.0) | 8.4.0 | 94 chars | none |
| `^9.3.1` (this PR) | 8.4.0 | 365 chars | Features + Bug Fixes |

As a control, the same commits through the default (angular) preset render correctly in both cases, which confirms the preset is at fault rather than the test harness.

For completeness, `conventional-changelog-conventionalcommits@10.4.0` — currently offered in #374 — adds a `createLegacyWriterGuard` that makes exactly this pairing throw instead of failing silently:

```
Missing helper: "conventional-changelog-conventionalcommits requires conventional-changelog-writer@9
or newer (conventional-changelog@8 or newer). Your changelog tooling loaded an older writer which
cannot render this preset. Update the tooling or use an older major version of the preset."
```

So #374 does not cause the problem; it surfaces one that is already here. That PR should be closed in favour of this one.

CI never caught it because `Release` is skipped on pull requests, so the failure would only appear on a release run against `main`.

## Change

- Pin `conventional-changelog-conventionalcommits` to `^9` (applied via `npm i -D`, so the manifest and lockfile stay canonical).
- Ignore `version-update:semver-major` for that package in `dependabot.yml`, with a comment explaining why and when to remove it.

There is no forward path yet: neither `@semantic-release/release-notes-generator@14.1.1` (latest) nor `15.0.0-beta.1` declares a writer 9 dependency, so 10.x cannot be used with semantic-release at all today. The ignore should be dropped once that changes.

The lockfile gets *smaller*: with the top-level preset back on 9.3.1 it matches what `@commitlint/config-conventional` already needed, so the nested duplicate collapses onto the hoisted copy and `@conventional-changelog/template` drops out. Nothing is added.

Worth noting the sibling repos never hit this because they are still on the 9.x line — `node-http-message-signatures` resolves 9.3.1 and `tediousjs/connection-string` resolves 9.3.0. This repo was the outlier.

## Verification

- `npm run lint` — exit 0
- `npm run build` — exit 0
- `npm test` — 54 passing
- Release notes render both sections, per the table above

---

**Copilot sessions**

| Session | Notes |
|---------|-------|
| `dbc91314-1399-4af3-8e1d-a599e6657ea3` | initial implementation — found while reviewing the Dependabot PR |
